### PR TITLE
Use app service plan

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -34,6 +34,8 @@ module "ia-apfr" {
   additional_host_name = "${var.env != "preview" ? var.additional_hostname : "null"}"
   https_only           = "${var.env != "preview" ? "true" : "true"}"
   common_tags          = "${var.common_tags}"
+  asp_rg               = "${var.product}-${var.component}-${var.env}"
+  asp_name             = "${var.product}-${var.component}-${var.env}"
 
   app_settings = {
     WEBSITE_NODE_DEFAULT_VERSION = "8.11.1"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,14 +1,23 @@
 provider "azurerm" {}
 
-resource "azurerm_resource_group" "rg" {
-  name     = "${var.product}-${var.component}-${var.env}"
-  location = "${var.location}"
-  tags     = "${merge(var.common_tags, map("lastUpdated", "${timestamp()}"))}"
+locals {
+
+  preview_resource_group_name     = "${var.product}-${var.component}-${var.env}"
+  non_preview_resource_group_name = "${var.product}-${var.env}"
+  resource_group_name             = "${var.env == "preview" || var.env == "spreview" ? local.preview_resource_group_name : local.non_preview_resource_group_name}"
+
+  preview_app_service_plan        = "${var.product}-${var.component}-${var.env}"
+  non_preview_app_service_plan    = "${var.product}-${var.env}"
+  app_service_plan                = "${var.env == "preview" || var.env == "spreview" ? local.preview_app_service_plan : local.non_preview_app_service_plan}"
+
+  preview_vault_name              = "${var.raw_product}-aat"
+  non_preview_vault_name          = "${var.raw_product}-${var.env}"
+  key_vault_name                  = "${var.env == "preview" || var.env == "spreview" ? local.preview_vault_name : local.non_preview_vault_name}"
 }
 
 data "azurerm_key_vault" "ia_key_vault" {
-  name                = "${local.vaultName}"
-  resource_group_name = "${local.vaultName}"
+  name                = "${local.key_vault_name}"
+  resource_group_name = "${local.key_vault_name}"
 }
 
 data "azurerm_key_vault_secret" "ia_case_api_url" {
@@ -16,26 +25,22 @@ data "azurerm_key_vault_secret" "ia_case_api_url" {
   vault_uri = "${data.azurerm_key_vault.ia_key_vault.vault_uri}"
 }
 
-locals {
-  aseName             = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
-  previewVaultName    = "${var.raw_product}-aat"
-  nonPreviewVaultName = "${var.raw_product}-${var.env}"
-  vaultName           = "${(var.env == "preview" || var.env == "spreview") ? local.previewVaultName : local.nonPreviewVaultName}"
-}
-
 module "ia-apfr" {
-  source               = "git@github.com:contino/moj-module-webapp?ref=master"
+  source               = "git@github.com:contino/cnp-module-webapp?ref=master"
   product              = "${var.product}-${var.component}"
   location             = "${var.location}"
   env                  = "${var.env}"
   ilbIp                = "${var.ilbIp}"
+  resource_group_name  = "${local.resource_group_name}"
   is_frontend          = "${var.env != "preview" ? 1: 0}"
   subscription         = "${var.subscription}"
   additional_host_name = "${var.env != "preview" ? var.additional_hostname : "null"}"
   https_only           = "${var.env != "preview" ? "true" : "true"}"
-  common_tags          = "${var.common_tags}"
-  asp_rg               = "${var.product}-${var.component}-${var.env}"
-  asp_name             = "${var.product}-${var.component}-${var.env}"
+  capacity             = "${var.capacity}"
+  instance_size        = "${var.instance_size}"
+  common_tags          = "${merge(var.common_tags, map("lastUpdated", "${timestamp()}"))}"
+  asp_name             = "${local.app_service_plan}"
+  asp_rg               = "${local.app_service_plan}"
 
   app_settings = {
     WEBSITE_NODE_DEFAULT_VERSION = "8.11.1"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,7 +1,19 @@
-output "vaultUri" {
-  value = "${data.azurerm_key_vault.ia_key_vault.vault_uri}"
+output "microserviceName" {
+  value = "${var.component}"
+}
+
+output "resourceGroup" {
+  value = "${local.resource_group_name}"
+}
+
+output "appServicePlan" {
+  value = "${local.app_service_plan}"
 }
 
 output "vaultName" {
-  value = "${local.vaultName}"
+  value = "${local.key_vault_name}"
+}
+
+output "vaultUri" {
+  value = "${data.azurerm_key_vault.ia_key_vault.vault_uri}"
 }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,0 +1,2 @@
+capacity = "2"
+instance_size="I2"

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,0 +1,2 @@
+capacity = "2"
+instance_size="I2"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,13 +1,14 @@
 variable "product" {
-  type    = "string"
+  type = "string"
 }
 
 variable "raw_product" {
-  default = "ia" // jenkins-library overrides product for PRs and adds e.g. pr-123-ia
+  default = "ia"
+  // jenkins-library overrides product for PRs and adds e.g. pr-123-ia
 }
 
 variable "component" {
-  type   = "string"
+  type = "string"
 }
 
 variable "location" {
@@ -28,22 +29,18 @@ variable "subscription" {
   type = "string"
 }
 
-variable "ilbIp"{}
-
-variable "tenant_id" {
-  description = "(Required) The Azure Active Directory tenant ID that should be used for authenticating requests to the key vault. This is usually sourced from environemnt variables and not normally required to be specified."
-}
-
-variable "client_id" {
-  description = "(Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. This is usually sourced from environment variables and not normally required to be specified."
-}
-
-variable "jenkins_AAD_objectId" {
-  type = "string"
-}
+variable "ilbIp" {}
 
 variable "common_tags" {
   type = "map"
+}
+
+variable "capacity" {
+  default = "1"
+}
+
+variable "instance_size" {
+  default = "I1"
 }
 
 variable "additional_hostname" {


### PR DESCRIPTION
In a few words: we currently use a service plan for application. After the change, we will have a single plan per project.

While we currently have a 1:1 mapping between applications and compute resources, with a shared plan we can fit more apps into a single compute resource.
The change is rolled out in two stages.

1. Explicitly enable the app service plan in Terraform
1. Switch the service plan to use a shared service plan.

**PLEASE NOTE, THIS PR IS FOR STEP 1 ONLY**

More info on the change: https://tools.hmcts.net/confluence/display/CNP/Migrate+to+Shared+App+Service+Plan (please note that the instructions are for the full migration).