### PR TITLE
RIA-3601: Added respondent notification failed image

### DIFF
--- a/app/assets/images/respondent_notification_failed.svg
+++ b/app/assets/images/respondent_notification_failed.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.6, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 963 156" style="enable-background:new 0 0 963 156;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#D0021B;}
+	.st1{fill:none;}
+	.st2{fill:#FFFFFF;}
+	.st3{font-family:'Arial-BoldMT';}
+	.st4{font-size:40px;}
+</style>
+<g>
+	<rect class="st0" width="963" height="156"/>
+</g>
+<rect x="0" y="58.8" class="st1" width="963" height="35.2"/>
+<text transform="matrix(1 0 0 1 60.3672 87.4009)" class="st2 st3 st4">The notification to the respondent has failed</text>
+</svg>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-3601


### Change description ###
 Added respondent notification failed image


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
